### PR TITLE
[DM-5743] Create and deploy Fluentd Ansible role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Example Playbook
 
     - hosts: server
       roles:
-         - { role: jmatt.fluentd }
+         - { role: jmatt.fluentd-packages }
 
 License
 -------
 
-See the [LICENSE file](/LICENSE).
+The MIT License. See the [LICENSE file](https://github.com/lsst-sqre/ansible-fluentd-packages/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+ansible-fluentd-packages
+========================
+
+[![Build Status](https://travis-ci.org/jmatt/ansible-fluentd-packages.svg?branch=master)](https://travis-ci.org/jmatt/ansible-fluentd-packages)
+
+Install Fluentd packages for LSST SQuaRE infrastructure.
+
+Example Playbook
+----------------
+
+    - hosts: server
+      roles:
+         - { role: jmatt.fluentd }
+
+License
+-------
+
+See the [LICENSE file](/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
-ansible-fluentd-packages
-========================
+fluentd-packages
+================
 
-[![Build Status](https://travis-ci.org/jmatt/ansible-fluentd-packages.svg?branch=master)](https://travis-ci.org/jmatt/ansible-fluentd-packages)
+[![Build Status](https://travis-ci.org/lsst-sqre/ansible-fluentd-packages.svg?branch=master)](https://travis-ci.org/lsst-sqre/ansible-fluentd-packages)
 
-Install Fluentd packages for LSST SQuaRE infrastructure.
+Install [Fluentd](http://www.fluentd.org/) packages using [Ansible](http://docs.ansible.com/) for LSST SQuaRE infrastructure.
 
 Example Playbook
 ----------------
 
     - hosts: server
       roles:
-         - { role: jmatt.fluentd-packages }
+         - { role: lsst-sqre.fluentd-packages }
+
+Versions
+--------
+
+Fluentd (td-agent v2 variant) using the [Treasure Data, Inc. repository](http://docs.fluentd.org/v0.12/categories/installation).
+
+Tested using Ansible 2.1 which is currently in development.
 
 License
 -------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   company: LSST SQuaRE
   issue_tracker_url: https://github.com/lsst-sqre/ansible-fluentd-packages/issues
   license: MIT
-  min_ansible_version: 2.0
+  min_ansible_version: 2.1
   platforms:
   - name: EL
     versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,27 @@
+galaxy_info:
+  author: J. Matt Peterson
+  description: LSST SQuaRE's fluentd packages.
+  company: LSST SQuaRE
+  issue_tracker_url: https://github.com/lsst-sqre/ansible-fluentd-packages/issues
+  license: MIT
+  min_ansible_version: 2.0
+  platforms:
+  - name: EL
+    versions:
+      - 7
+  - name: Ubuntu
+    versions:
+      - trusty
+      - xenial
+  #- name: Debian
+  #  versions:
+  #  - all
+  #  - etch
+  #  - jessie
+  #  - lenny
+  #  - squeeze
+  #  - wheezy
+  galaxy_tags:
+    - system
+    - monitoring
+dependencies: []

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,9 +1,6 @@
 ---
 # Install Fluentd (td-agent) packages on debian based distributions.
 
-- name: Uninstall existing Fluentd (td-agent) package.
-  apt: name=td-agent state=absent
-
 - name: Add Fluentd (TreasureData) apt key.
   apt_key:
     url: http://packages.treasuredata.com/GPG-KEY-td-agent

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -2,10 +2,9 @@
 # Install fluentd packages on debian based distributions.
 
 - name: Add Fluentd (TreasureData) apt key.
-  apt_key: url=https://packages.treasuredata.com/GPG-KEY-td-agent state=present
-
-- name: Install apt-transport-https dependency.
-  apt: name=apt-transport-https update_cache=yes state=latest install_recommends=no
+  apt_key:
+    url: http://packages.treasuredata.com/GPG-KEY-td-agent
+    state: present
 
 - name: Add the Fluentd (TreasureData) repository.
   apt_repository: repo='deb http://packages.treasuredata.com/2/ubuntu/trusty/ trusty contrib' state=present

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,0 +1,17 @@
+---
+# Install fluentd packages on debian based distributions.
+
+- name: Add Fluentd (TreasureData) apt key.
+  apt_key: url=https://packages.treasuredata.com/GPG-KEY-td-agent state=present
+
+- name: Install apt-transport-https dependency.
+  apt: name=apt-transport-https update_cache=yes state=latest install_recommends=no
+
+- name: Add the Fluentd (TreasureData) repository.
+  apt_repository: repo='deb http://packages.treasuredata.com/2/ubuntu/trusty/ trusty contrib' state=present
+
+- name: Install Fluentd (td-agent) package.
+  apt: name=td-agent update_cache=yes state=latest install_recommends=no
+
+- name: Configure Fluentd.
+  include: fluentd.yml

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,5 +1,8 @@
 ---
-# Install fluentd packages on debian based distributions.
+# Install Fluentd (td-agent) packages on debian based distributions.
+
+- name: Uninstall existing Fluentd (td-agent) package.
+  apt: name=td-agent state=absent
 
 - name: Add Fluentd (TreasureData) apt key.
   apt_key:

--- a/tasks/fluentd.yml
+++ b/tasks/fluentd.yml
@@ -1,0 +1,5 @@
+---
+# Configure the Fluentd (td-agent) service.
+
+- name: Start the Fluentd (td-agent) service.
+  service: name=td-agent state=started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# tasks file for fluentd
+
+- name: Stop the Fluentd (td-agent) service.
+  service: name=td-agent state=stopped
+  
+- include: redhat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include: debian.yml
+  when: ansible_os_family == 'Debian'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
-# tasks file for fluentd
+# tasks file for fluentd-packages
+
+- name: Stop the fluentd service.
+  service: name=td-agent state=stopped
+  ignore_errors: true
 
 - include: redhat.yml
   when: ansible_os_family == 'RedHat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,6 @@
 ---
 # tasks file for fluentd
 
-- name: Stop the Fluentd (td-agent) service.
-  service: name=td-agent state=stopped
-  
 - include: redhat.yml
   when: ansible_os_family == 'RedHat'
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,9 +1,6 @@
 ---
 # Install Fluentd (td-agent) packages on redhat base distributions.
 
-- name: Uninstall existing Fluentd (td-agent) package.
-  yum: name=td-agent state=absent
-
 - name: Add the Fluentd (TreasureData) repository.
   yum_repository:
     name: TreasureData-repository

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,0 +1,18 @@
+---
+# Install Fluentd packages on redhat base distributions.
+
+- name: Add the Fluentd (TreasureData) repository.
+  yum_repository:
+    name: TreasureData / Fluentd repository.
+    description: TreasureData / Fluentd repository for fluentd packages.
+    baseurl: http://packages.treasuredata.com/2/redhat/\$releasever/\$basearch
+    gpgkey: https://packages.treasuredata.com/GPG-KEY-td-agent
+    gpgcheck: yes
+    enabled: yes
+    file: td.repo
+
+- name: Install Fluentd (td-agent) package.
+  yum: name=td-agent state=latest
+
+- name: Configure Fluentd.
+  include: fluentd.yml

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,15 +1,18 @@
 ---
-# Install Fluentd packages on redhat base distributions.
+# Install Fluentd (td-agent) packages on redhat base distributions.
+
+- name: Uninstall existing Fluentd (td-agent) package.
+  yum: name=td-agent state=absent
 
 - name: Add the Fluentd (TreasureData) repository.
   yum_repository:
-    name: TreasureData / Fluentd repository.
-    description: TreasureData / Fluentd repository for fluentd packages.
-    baseurl: http://packages.treasuredata.com/2/redhat/\$releasever/\$basearch
+    name: TreasureData-repository
+    description: TreasureData and Fluentd repository for fluentd packages.
+    baseurl: http://packages.treasuredata.com/2/redhat/$releasever/$basearch
     gpgkey: https://packages.treasuredata.com/GPG-KEY-td-agent
     gpgcheck: yes
     enabled: yes
-    file: td.repo
+    file: td
 
 - name: Install Fluentd (td-agent) package.
   yum: name=td-agent state=latest

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - ansible-fluentd.packages
+    - ansible-fluentd-packages

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ansible-fluentd.packages


### PR DESCRIPTION
Create and deploy Logstash, Fluentd and Riemann Ansible roles for LSST SQuaRE infrastructure.
- [x] Install Fluentd (td-agent v2 variant) using the Treasure Data, Inc repository.
- [x] Verify using travis.ci.
- [x] Available as Ansible Galaxy role `lsst-sqre.fluentd-packages`. After PR is accepted and Ansible Galaxy is updated.
